### PR TITLE
Fix: std.in syscall when building for windows

### DIFF
--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"os"
-	"syscall"
 )
 
 type User struct {
@@ -43,7 +42,7 @@ func SaveUser() error {
 	fmt.Scanln(&username)
 
 	fmt.Println("Provide your personal github token: ")
-	b, _ := terminal.ReadPassword(syscall.Stdin)
+	b, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 
 	home, _ := os.UserHomeDir()
 


### PR DESCRIPTION
Fixed issue #5 when building for windows based platforms 